### PR TITLE
Added management of multiple server URLs

### DIFF
--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -75,13 +75,12 @@ var _ = Describe("Rabbit", func() {
 
 			It("happy: it should succeed after having failed on unreachable rabbit server", func() {
 				opts := generateOptions()
-				opts.URLs = []string{"amqp://bad-url"}
+				opts.URLs = []string{"amqp://bad-url", "amqp://localhost"}
 
 				r, err := New(opts)
 
-				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(ContainSubstring("unable to dial server"))
-				Expect(r).To(BeNil())
+				Expect(err).To(BeNil())
+				Expect(r).ToNot(BeNil())
 			})
 
 			It("instantiates various internals", func() {


### PR DESCRIPTION
Hallo,
I'm proposing a change to handle multiple servers (e.g. in a cluster). This is to address the case where one is building a client that needs to keep working even when it cannot connect to one or more RabbitMQ nodes in a cluster (see [the RabbitMQ docs](https://www.rabbitmq.com/distributed.html#clustering)).
The change is simple and involves:

1. having a `[]string` slice for the URLs and 
2. looping over the slice values attempting to connect until one succeeds. 
 
I have changed the relevant tests and added a test to specifically verify that when the slice contains a bad address and a good one, the client can eventually connect after having failed on the bad one.
First of all let me thank you for the excellent code, it's the best wrapper on amqp/streadway I've found so far.
I need this feature badly (I'm building a distributed service that runs on three data centers and it must be as resilient to network partitions as I can make it) so I had to make these changes for myself. I hope someone else will benefit my changes.

Let me know if you think the PR valuable and if you think it needs improvements.

Cheers!
