### PR TITLE
feature: add context support to Publish method

### DIFF
--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -497,6 +497,26 @@ var _ = Describe("Rabbit", func() {
 			})
 		})
 
+		Context("context timeout", func() {
+			It("returns an error on context timeout", func() {
+
+				go func() {
+					var err error
+					_, err = receiveMessage(ch, opts)
+
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				testMessage := []byte(uuid.NewV4().String())
+				publishErr := r.Publish(ctx, opts.Bindings[0].BindingKeys[0], testMessage)
+
+				Expect(publishErr).To(HaveOccurred())
+			})
+		})
+
 		When("producer server channel is nil", func() {
 			It("will generate a new server channel", func() {
 				r.ProducerServerChannel = nil

--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
+
 	// to test with logrus, uncomment the following
 	// and the log initialiser in generateOptions()
 	// "github.com/sirupsen/logrus"
@@ -499,14 +500,6 @@ var _ = Describe("Rabbit", func() {
 
 		Context("context timeout", func() {
 			It("returns an error on context timeout", func() {
-
-				go func() {
-					var err error
-					_, err = receiveMessage(ch, opts)
-
-					Expect(err).ToNot(HaveOccurred())
-				}()
-
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 


### PR DESCRIPTION
Hi,

This is my attempt at adding `context.Context` support to the Publish method.

Since there isn't context support in the `amqp` library `Publish` method, I opted to call `Connection.Close`. Hopefully this is correct.

Thanks for checking 😄 

Closes #14 