### PR TITLE
Consumer looper CPU fix

### DIFF
--- a/rabbit.go
+++ b/rabbit.go
@@ -542,14 +542,15 @@ func (r *Rabbit) Close() error {
 }
 
 func (r *Rabbit) watchNotifyClose() {
+
 	// TODO: Use a looper here
 	for {
-		//select {
-		//case <-r.ctx.Done():
-		//	return
-		//case closeErr := <-r.NotifyCloseChan:
-		//	r.log.Debugf("received message on notify close channel: '%+v' (reconnecting)", closeErr)
-		//}
+		select {
+		case <-r.ctx.Done():
+			return
+		case closeErr := <-r.NotifyCloseChan:
+			r.log.Debugf("received message on notify close channel: '%+v' (reconnecting)", closeErr)
+		}
 
 		// Exit consumer looper until we've reconnected
 		var initConsumerLooper bool

--- a/rabbit.go
+++ b/rabbit.go
@@ -567,11 +567,6 @@ func (r *Rabbit) watchNotifyClose() {
 				continue
 			}
 			r.log.Debugf("successfully reconnected after %d attempts", attempts)
-
-			// Make new looper since we quit the one above
-			if initConsumerLooper {
-				r.ConsumeLooper = director.NewFreeLooper(director.FOREVER, make(chan error, 1))
-			}
 			break
 		}
 
@@ -594,6 +589,11 @@ func (r *Rabbit) watchNotifyClose() {
 
 				// TODO: This is super shitty. Should address this.
 				panic(fmt.Sprintf("unable to set new channel: %s", err))
+			}
+
+			// Make new looper since we quit the one above
+			if initConsumerLooper {
+				r.ConsumeLooper = director.NewFreeLooper(director.FOREVER, make(chan error, 1))
 			}
 		}
 


### PR DESCRIPTION
* When a connection failure occurs, exit consumer looper and re-initialize after reconnect
* Added tiny sleep after an error occurs during Consumer() to prevent flood of goroutines eating up CPU