### PR TITLE
Runaway CPU fix

### DIFF
--- a/rabbit.go
+++ b/rabbit.go
@@ -588,6 +588,8 @@ func (r *Rabbit) watchNotifyClose() {
 				// TODO: This is super shitty. Should address this.
 				panic(fmt.Sprintf("unable to set new channel: %s", err))
 			}
+
+			r.log.Debug("successfully set new consumer channel"")
 		}
 
 		// Unlock so that consumers/producers can begin reading messages from a new channel

--- a/rabbit.go
+++ b/rabbit.go
@@ -589,7 +589,7 @@ func (r *Rabbit) watchNotifyClose() {
 				panic(fmt.Sprintf("unable to set new channel: %s", err))
 			}
 
-			r.log.Debug("successfully set new consumer channel"")
+			r.log.Debug("successfully set new consumer channel")
 		}
 
 		// Unlock so that consumers/producers can begin reading messages from a new channel


### PR DESCRIPTION
* Ignore "delivery not initialized" error and add sleep afterwards to prevent loop flood
* Adding sleep after `newServerChannel()` on reconnects to allow time for rabbit rebalance after a node loss, otherwise a panic() will occur
